### PR TITLE
Prevent sequential block files from being created

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1451,68 +1451,72 @@ bool UndoWriteToDisk(const CBlockUndo &blockundo,
     const uint256 &hashBlock,
     const CMessageHeader::MessageStartChars &messageStart)
 {
-    if (BLOCK_DB_MODE != LEVELDB_BLOCK_STORAGE)
+    // No need for writing undo to disk of we are only using leveldb for block storage.
+    if (BLOCK_DB_MODE == LEVELDB_BLOCK_STORAGE)
+        return true;
+
+    // Open history file to append
+    CAutoFile fileout(OpenUndoFile(pos), SER_DISK, CLIENT_VERSION);
+    if (fileout.IsNull())
     {
-        // Open history file to append
-        CAutoFile fileout(OpenUndoFile(pos), SER_DISK, CLIENT_VERSION);
-        if (fileout.IsNull())
-        {
-            return error("%s: OpenUndoFile failed", __func__);
-        }
-
-        // Write index header
-        unsigned int nSize = GetSerializeSize(fileout, blockundo);
-        fileout << FLATDATA(messageStart) << nSize;
-
-        // Write undo data
-        long fileOutPos = ftell(fileout.Get());
-        if (fileOutPos < 0)
-        {
-            return error("%s: ftell failed", __func__);
-        }
-        pos.nPos = (unsigned int)fileOutPos;
-        fileout << blockundo;
-
-        // calculate & write checksum
-        CHashWriter hasher(SER_GETHASH, PROTOCOL_VERSION);
-        hasher << hashBlock;
-        hasher << blockundo;
-        fileout << hasher.GetHash();
+        return error("%s: OpenUndoFile failed", __func__);
     }
+
+    // Write index header
+    unsigned int nSize = GetSerializeSize(fileout, blockundo);
+    fileout << FLATDATA(messageStart) << nSize;
+
+    // Write undo data
+    long fileOutPos = ftell(fileout.Get());
+    if (fileOutPos < 0)
+    {
+        return error("%s: ftell failed", __func__);
+    }
+    pos.nPos = (unsigned int)fileOutPos;
+    fileout << blockundo;
+
+    // calculate & write checksum
+    CHashWriter hasher(SER_GETHASH, PROTOCOL_VERSION);
+    hasher << hashBlock;
+    hasher << blockundo;
+    fileout << hasher.GetHash();
+
     return true;
 }
 
 bool UndoReadFromDisk(CBlockUndo &blockundo, const CDiskBlockPos &pos, const uint256 &hashBlock)
 {
-    if (BLOCK_DB_MODE != LEVELDB_BLOCK_STORAGE)
+    // No need for reading undo from disk of we are only using leveldb for block storage.
+    if (BLOCK_DB_MODE == LEVELDB_BLOCK_STORAGE)
+        return true;
+
+    // Open history file to read
+    CAutoFile filein(OpenUndoFile(pos, true), SER_DISK, CLIENT_VERSION);
+    if (filein.IsNull())
     {
-        // Open history file to read
-        CAutoFile filein(OpenUndoFile(pos, true), SER_DISK, CLIENT_VERSION);
-        if (filein.IsNull())
-        {
-            return error("%s: OpenUndoFile failed", __func__);
-        }
-
-        // Read block
-        uint256 hashChecksum;
-        CHashVerifier<CAutoFile> verifier(&filein); // We need a CHashVerifier as reserializing may lose data
-        try
-        {
-            verifier << hashBlock;
-            verifier >> blockundo;
-            filein >> hashChecksum;
-        }
-        catch (const std::exception &e)
-        {
-            return error("%s: Deserialize or I/O error - %s", __func__, e.what());
-        }
-
-        // Verify checksum
-        if (hashChecksum != verifier.GetHash())
-        {
-            return error("%s: Checksum mismatch", __func__);
-        }
+        return error("%s: OpenUndoFile failed", __func__);
     }
+
+    // Read block
+    uint256 hashChecksum;
+    CHashVerifier<CAutoFile> verifier(&filein); // We need a CHashVerifier as reserializing may lose data
+    try
+    {
+        verifier << hashBlock;
+        verifier >> blockundo;
+        filein >> hashChecksum;
+    }
+    catch (const std::exception &e)
+    {
+        return error("%s: Deserialize or I/O error - %s", __func__, e.what());
+    }
+
+    // Verify checksum
+    if (hashChecksum != verifier.GetHash())
+    {
+        return error("%s: Checksum mismatch", __func__);
+    }
+
     return true;
 }
 
@@ -2156,37 +2160,37 @@ bool ConnectBlock(const CBlock &block,
 
 
     // Write undo information to disk
-    if (pindex->GetUndoPos().IsNull() || !pindex->IsValid(BLOCK_VALID_SCRIPTS))
+    if (BLOCK_DB_MODE == SEQUENTIAL_BLOCK_FILES || BLOCK_DB_MODE == LEVELDB_AND_SEQUENTIAL)
     {
-        if (pindex->GetUndoPos().IsNull())
+        if (pindex->GetUndoPos().IsNull() || !pindex->IsValid(BLOCK_VALID_SCRIPTS))
         {
-            CDiskBlockPos pos;
-            if (BLOCK_DB_MODE == SEQUENTIAL_BLOCK_FILES || BLOCK_DB_MODE == LEVELDB_AND_SEQUENTIAL)
+            if (pindex->GetUndoPos().IsNull())
             {
+                CDiskBlockPos pos;
                 if (!FindUndoPos(
                         state, pindex->nFile, pos, ::GetSerializeSize(blockundo, SER_DISK, CLIENT_VERSION) + 40))
                 {
                     return error("ConnectBlock(): FindUndoPos failed");
                 }
+
+
+                uint256 prevHash;
+                if (pindex->pprev) // genesis block prev hash is 0
+                {
+                    prevHash = pindex->pprev->GetBlockHash();
+                }
+                else
+                {
+                    prevHash.SetNull();
+                }
+                if (!UndoWriteToDisk(blockundo, pos, prevHash, chainparams.MessageStart()))
+                    return AbortNode(state, "Failed to write undo data");
+
+
+                // update nUndoPos in block index
+                pindex->nUndoPos = pos.nPos;
+                pindex->nStatus |= BLOCK_HAVE_UNDO;
             }
-
-
-            uint256 prevHash;
-            if (pindex->pprev) // genesis block prev hash is 0
-            {
-                prevHash = pindex->pprev->GetBlockHash();
-            }
-            else
-            {
-                prevHash.SetNull();
-            }
-            if (!UndoWriteToDisk(blockundo, pos, prevHash, chainparams.MessageStart()))
-                return AbortNode(state, "Failed to write undo data");
-
-
-            // update nUndoPos in block index
-            pindex->nUndoPos = pos.nPos;
-            pindex->nStatus |= BLOCK_HAVE_UNDO;
         }
 
         pindex->RaiseValidity(BLOCK_VALID_SCRIPTS);
@@ -3154,6 +3158,10 @@ bool FindBlockPos(CValidationState &state,
     uint64_t nTime,
     bool fKnown = false)
 {
+    // No need for finding block pos if we're only using leveldb for block storage.
+    if (BLOCK_DB_MODE == LEVELDB_BLOCK_STORAGE)
+        return true;
+
     LOCK(cs_LastBlockFile);
 
     unsigned int nFile = fKnown ? pos.nFile : nLastBlockFile;
@@ -3204,17 +3212,13 @@ bool FindBlockPos(CValidationState &state,
             }
             if (CheckDiskSpace(nNewChunks * BLOCKFILE_CHUNK_SIZE - pos.nPos))
             {
-                /// dont actually open and allocate file space if we are running levelDB
-                if(BLOCK_DB_MODE != LEVELDB_BLOCK_STORAGE)
+                FILE *file = OpenBlockFile(pos);
+                if (file)
                 {
-                    FILE *file = OpenBlockFile(pos);
-                    if (file)
-                    {
-                        LOGA("Pre-allocating up to position 0x%x in blk%05u.dat\n", nNewChunks * BLOCKFILE_CHUNK_SIZE,
-                            pos.nFile);
-                        AllocateFileRange(file, pos.nPos, nNewChunks * BLOCKFILE_CHUNK_SIZE - pos.nPos);
-                        fclose(file);
-                    }
+                    LOGA("Pre-allocating up to position 0x%x in blk%05u.dat\n", nNewChunks * BLOCKFILE_CHUNK_SIZE,
+                        pos.nFile);
+                    AllocateFileRange(file, pos.nPos, nNewChunks * BLOCKFILE_CHUNK_SIZE - pos.nPos);
+                    fclose(file);
                 }
             }
             else
@@ -3891,11 +3895,11 @@ bool static LoadBlockIndexDB()
             (pindexBestHeader == nullptr || CBlockIndexWorkComparator()(pindexBestHeader, pindex)))
             pindexBestHeader = pindex;
     }
-    
-    if(BLOCK_DB_MODE != LEVELDB_BLOCK_STORAGE)
+
+    if (BLOCK_DB_MODE != LEVELDB_BLOCK_STORAGE)
     {
         // Check presence of blk files
-        
+
         LOGA("Checking all blk files are present...\n");
         for (std::set<int>::iterator it = setBlkDataFiles.begin(); it != setBlkDataFiles.end(); it++)
         {
@@ -3906,7 +3910,7 @@ bool static LoadBlockIndexDB()
                 return false;
             }
         }
-            // Load block file info
+        // Load block file info
         pblocktree->ReadLastBlockFile(nLastBlockFile);
         vinfoBlockFile.resize(nLastBlockFile + 1);
         LOGA("%s: last block file = %i\n", __func__, nLastBlockFile);


### PR DESCRIPTION
Block files were being created during IBD when only in LevelDB mode
due to the FindBlockPos() which should not be executed when in
LevelDB mode.

@Greg-Griffith You can take this code of leave it, it's up to you. Just wanted to point out where the problem was with the sequential files.  We don't often submit PR's to each other's branches but sometimes it saves time in going back and forth...it's easier just to show the code than try to explain it over a chat channel.

Also there's a bit of cleanup in here.  Mostly indentation, there isn't any new code here except the  "if (BLOCK_DB_MODE == LEVELDB_BLOCK_STORAGE)"