### PR TITLE
Set the best block hash in ConnectBlock() and DisconnectBlock()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1518,6 +1518,12 @@ static DisconnectResult DisconnectBlock(const CBlock &block, const CBlockIndex *
     // move best block pointer to prevout block
     view.SetBestBlock(pindex->pprev->GetBlockHash());
 
+    // if we are not set to sequential, update the best block hash for leveldb storage
+    if(BLOCK_DB_MODE != SEQUENTIAL_BLOCK_FILES)
+    {
+        pcoinsdbview->WriteBestBlockDb(pindex->pprev->GetBlockHash());
+    }
+
     return fClean ? DISCONNECT_OK : DISCONNECT_UNCLEAN;
 }
 
@@ -1735,6 +1741,12 @@ bool ConnectBlock(const CBlock &block,
         if (!fJustCheck)
         {
             view.SetBestBlock(pindex->GetBlockHash());
+
+            // if we are not set to sequential, update the best block hash for leveldb storage
+            if(BLOCK_DB_MODE != SEQUENTIAL_BLOCK_FILES)
+            {
+                pcoinsdbview->WriteBestBlockDb(pindex->GetBlockHash());
+            }
         }
         return true;
     }
@@ -2083,6 +2095,12 @@ bool ConnectBlock(const CBlock &block,
 
     // add this block to the view's block chain (the main UTXO in memory cache)
     view.SetBestBlock(pindex->GetBlockHash());
+
+    // if we are not set to sequential, update the best block hash for leveldb storage
+    if(BLOCK_DB_MODE != SEQUENTIAL_BLOCK_FILES)
+    {
+        pcoinsdbview->WriteBestBlockDb(pindex->GetBlockHash());
+    }
 
     int64_t nTime5 = GetTimeMicros();
     nTimeIndex += nTime5 - nTime4;


### PR DESCRIPTION
We have to set the best block hash at these places. If we do it
later after ActivateBestChain then we may end up a few blocks
behind because ActivateBestChain can connect many blocks at at
time and then have its thread interrupted which means the best
block hash will be incorrect. It's better to update the block
hash directly after connecting or disconnecting a block.