### PR TITLE
Create a database key that will sort by time

### DIFF
--- a/src/blockdb/blockdb.cpp
+++ b/src/blockdb/blockdb.cpp
@@ -47,21 +47,33 @@ bool ReadBlockFromDB(const CBlockIndex *pindex, BlockDBValue &value)
     return pblockdb->Read(key.str(), value);
 }
 
-bool UndoWriteToDB(const CBlockUndo &blockundo, const uint256 &hashBlock)
+bool UndoWriteToDB(const CBlockUndo &blockundo, const uint256 &hashBlock, const int64_t nBlockTime)
 {
+    // Create a key which will sort the database by the blocktime.  This is needed to prevent unnecessary
+    // compactions which hamper performance. Will a key sorted by time the only files that need to undergo
+    // compaction are the most recent files only.
+    std::ostringstream key;
+    key << nBlockTime << ":" << hashBlock.ToString();
+
     // calculate & write checksum
     CHashWriter hasher(SER_GETHASH, PROTOCOL_VERSION);
     hasher << hashBlock;
     hasher << blockundo;
     UndoDBValue value(hasher.GetHash(), hashBlock, blockundo);
-    return pblockundodb->Write(hashBlock, value);
+    return pblockundodb->Write(key.str(), value);
 }
 
-bool UndoReadFromDB(CBlockUndo &blockundo, const uint256 &hashBlock)
+bool UndoReadFromDB(CBlockUndo &blockundo, const uint256 &hashBlock, const int64_t nBlockTime)
 {
+    // Create a key which will sort the database by the blocktime.  This is needed to prevent unnecessary
+    // compactions which hamper performance. Will a key sorted by time the only files that need to undergo
+    // compaction are the most recent files only.
+    std::ostringstream key;
+    key << nBlockTime << ":" << hashBlock.ToString();
+
     // Read block
     UndoDBValue value;
-    if(!pblockundodb->Read(hashBlock, value))
+    if(!pblockundodb->Read(key.str(), value))
     {
         return error("%s: failure to read undoblock from db", __func__);
     }

--- a/src/blockdb/blockdb.cpp
+++ b/src/blockdb/blockdb.cpp
@@ -26,13 +26,25 @@ bool CBlockDB::WriteBatchSync(const std::vector<CBlock> &blocks)
 
 bool WriteBlockToDB(const CBlock &block)
 {
+    // Create a key which will sort the database by the blocktime.  This is needed to prevent unnecessary
+    // compactions which hamper performance. Will a key sorted by time the only files that need to undergo
+    // compaction are the most recent files only.
+    std::ostringstream key;
+    key << block.GetBlockTime() << ":" << block.GetHash().ToString();
+
     BlockDBValue value(block);
-    return pblockdb->Write(block.GetHash(), value);
+    return pblockdb->Write(key.str(), value);
 }
 
 bool ReadBlockFromDB(const CBlockIndex *pindex, BlockDBValue &value)
 {
-    return pblockdb->Read(pindex->GetBlockHash(), value);
+    // Create a key which will sort the database by the blocktime.  This is needed to prevent unnecessary
+    // compactions which hamper performance. Will a key sorted by time the only files that need to undergo
+    // compaction are the most recent files only.
+    std::ostringstream key;
+    key << pindex->GetBlockTime() << ":" << pindex->GetBlockHash().ToString();
+
+    return pblockdb->Read(key.str(), value);
 }
 
 bool UndoWriteToDB(const CBlockUndo &blockundo, const uint256 &hashBlock)

--- a/src/blockdb/blockdb.h
+++ b/src/blockdb/blockdb.h
@@ -110,8 +110,8 @@ extern CBlockDB *pblockundodb;
 bool WriteBlockToDB(const CBlock &block);
 bool ReadBlockFromDB(const CBlockIndex *pindex, BlockDBValue &value);
 
-bool UndoWriteToDB(const CBlockUndo &blockundo, const uint256 &hashBlock);
-bool UndoReadFromDB(CBlockUndo &blockundo, const uint256 &hashBlock);
+bool UndoWriteToDB(const CBlockUndo &blockundo, const uint256 &hashBlock, const int64_t nBlockTime);
+bool UndoReadFromDB(CBlockUndo &blockundo, const uint256 &hashBlock, const int64_t nBlockTime);
 
 uint64_t FindFilesToPruneLevelDB(uint64_t nLastBlockWeCanPrune);
 

--- a/src/blockdb/wrapper.cpp
+++ b/src/blockdb/wrapper.cpp
@@ -171,7 +171,7 @@ void SyncStorage(const CChainParams &chainparams)
                 if(pindexNew->nStatus & BLOCK_HAVE_UNDO && item.second.nUndoPos != 0)
                 {
                     CBlockUndo blockundo;
-                    if(UndoReadFromDB(blockundo, pindexNew->GetBlockHash()))
+                    if(UndoReadFromDB(blockundo, pindexNew->GetBlockHash(), pindexNew->GetBlockTime()))
                     {
                         CDiskBlockPos pos;
                         if (!FindUndoPos(state, pindexNew->nFile, pos, ::GetSerializeSize(blockundo, SER_DISK, CLIENT_VERSION) + 40))
@@ -188,7 +188,7 @@ void SyncStorage(const CChainParams &chainparams)
                         {
                             prevHash.SetNull();
                         }
-                        if (!UndoWriteToDisk(blockundo, pos, prevHash, chainparams.MessageStart()))
+                        if (!UndoWriteToDisk(blockundo, pos, prevHash, pindexNew->GetBlockTime(), chainparams.MessageStart()))
                         {
                             LOGA("SyncStorage(): Failed to write undo data");
                             assert(false);
@@ -246,7 +246,7 @@ void SyncStorage(const CChainParams &chainparams)
                         if(tempindex->nStatus & BLOCK_HAVE_UNDO && tempindex->nUndoPos != 0)
                         {
                             CBlockUndo blockundo;
-                            if(!UndoReadFromDB(blockundo, it->second->GetBlockHash()))
+                            if(!UndoReadFromDB(blockundo, it->second->GetBlockHash(), it->second->GetBlockTime()))
                             {
                                 LOGA("SyncStorage(): failed to read undo data for block with hash %s \n", it->second->GetBlockHash().GetHex().c_str());
                                 continue;
@@ -266,7 +266,7 @@ void SyncStorage(const CChainParams &chainparams)
                             {
                                 prevHash.SetNull();
                             }
-                            if (!UndoWriteToDisk(blockundo, pos, prevHash, chainparams.MessageStart()))
+                            if (!UndoWriteToDisk(blockundo, pos, prevHash, it->second->GetBlockTime(), chainparams.MessageStart()))
                             {
                                 LOGA("SyncStorage(): Failed to write undo data");
                                 assert(false);
@@ -379,7 +379,7 @@ void SyncStorage(const CChainParams &chainparams)
                     LOGA("SyncStorage(): critical error, failure to read undo data from sequential files \n");
                     assert(false);
                 }
-                if(!UndoWriteToDB(blockundo, index->pprev->GetBlockHash()))
+                if(!UndoWriteToDB(blockundo, index->pprev->GetBlockHash(), index->GetBlockTime()))
                 {
                     LOGA("critical error, failed to write undo to db, asserting false \n");
                     assert(false);
@@ -453,7 +453,7 @@ bool ReadBlockFromDisk(CBlock &block, const CBlockIndex *pindex, const Consensus
     return false;
 }
 
-bool UndoWriteToDisk(const CBlockUndo &blockundo, CDiskBlockPos &pos, const uint256 &hashBlock, const CMessageHeader::MessageStartChars &messageStart)
+bool UndoWriteToDisk(const CBlockUndo &blockundo, CDiskBlockPos &pos, const uint256 &hashBlock, const int64_t nBlockTime, const CMessageHeader::MessageStartChars &messageStart)
 {
     if(BLOCK_DB_MODE == SEQUENTIAL_BLOCK_FILES)
     {
@@ -461,13 +461,13 @@ bool UndoWriteToDisk(const CBlockUndo &blockundo, CDiskBlockPos &pos, const uint
     }
     else if(BLOCK_DB_MODE == DB_BLOCK_STORAGE)
     {
-        return UndoWriteToDB(blockundo, hashBlock);
+        return UndoWriteToDB(blockundo, hashBlock, nBlockTime);
     }
     // default return of false
     return false;
 }
 
-bool UndoReadFromDisk(CBlockUndo &blockundo, const CDiskBlockPos &pos, const uint256 &hashBlock)
+bool UndoReadFromDisk(CBlockUndo &blockundo, const CDiskBlockPos &pos, const uint256 &hashBlock, const int64_t nBlockTime)
 {
     if(BLOCK_DB_MODE == SEQUENTIAL_BLOCK_FILES)
     {
@@ -475,7 +475,7 @@ bool UndoReadFromDisk(CBlockUndo &blockundo, const CDiskBlockPos &pos, const uin
     }
     else if(BLOCK_DB_MODE == DB_BLOCK_STORAGE)
     {
-        return UndoReadFromDB(blockundo, hashBlock);
+        return UndoReadFromDB(blockundo, hashBlock, nBlockTime);
     }
     // default return of false
     return true;

--- a/src/blockdb/wrapper.h
+++ b/src/blockdb/wrapper.h
@@ -35,8 +35,8 @@ void SyncStorage(const CChainParams &chainparams);
 bool ReadBlockFromDisk(CBlock &block, const CBlockIndex *pindex, const Consensus::Params &consensusParams);
 bool WriteBlockToDisk(const CBlock &block, CDiskBlockPos &pos, const CMessageHeader::MessageStartChars &messageStart);
 
-bool UndoWriteToDisk(const CBlockUndo &blockundo, CDiskBlockPos &pos, const uint256 &hashBlock, const CMessageHeader::MessageStartChars &messageStart);
-bool UndoReadFromDisk(CBlockUndo &blockundo, const CDiskBlockPos &pos, const uint256 &hashBlock);
+bool UndoWriteToDisk(const CBlockUndo &blockundo, CDiskBlockPos &pos, const uint256 &hashBlock, const int64_t nBlockTime, const CMessageHeader::MessageStartChars &messageStart);
+bool UndoReadFromDisk(CBlockUndo &blockundo, const CDiskBlockPos &pos, const uint256 &hashBlock, const int64_t nBlockTime);
 
 /**
  * Prune block and undo files (blk???.dat and undo???.dat) so that the disk space used is less than a user-defined

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1464,7 +1464,7 @@ static DisconnectResult DisconnectBlock(const CBlock &block, const CBlockIndex *
         error("DisconnectBlock(): no undo data available");
         return DISCONNECT_FAILED;
     }
-    if (!UndoReadFromDisk(blockUndo, pos, pindex->pprev->GetBlockHash()))
+    if (!UndoReadFromDisk(blockUndo, pos, pindex->pprev->GetBlockHash(), pindex->GetBlockTime()))
     {
         error("DisconnectBlock(): failure reading undo data");
         return DISCONNECT_FAILED;
@@ -2066,7 +2066,7 @@ bool ConnectBlock(const CBlock &block,
             {
                 prevHash.SetNull();
             }
-            if (!UndoWriteToDisk(blockundo, pos, prevHash, chainparams.MessageStart()))
+            if (!UndoWriteToDisk(blockundo, pos, prevHash, pindex->GetBlockTime(), chainparams.MessageStart()))
             {
                 return AbortNode(state, "Failed to write undo data");
             }
@@ -3964,7 +3964,7 @@ bool CVerifyDB::VerifyDB(const CChainParams &chainparams, CCoinsView *coinsview,
             CDiskBlockPos pos = pindex->GetUndoPos();
             if (!pos.IsNull())
             {
-                if (!UndoReadFromDisk(undo, pos, pindex->pprev->GetBlockHash()))
+                if (!UndoReadFromDisk(undo, pos, pindex->pprev->GetBlockHash(), pindex->GetBlockTime()))
                     return error("VerifyDB(): *** found bad undo data at %d, hash=%s\n", pindex->nHeight,
                         pindex->GetBlockHash().ToString());
             }


### PR DESCRIPTION
By prefixing the block hash with the blocktime plus a ":" separator
the records will now be sorted by time on disk. This has a large
perforance benefit in reducing the frequency and scope of database
compactions.  The only files that now undergo compaction are the most
recent one created, rather than any and all files as was the previous
case.