### PR TITLE
catch exception in ConnectBlock

### DIFF
--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -69,7 +69,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
 
     // put the transactions in LTOR ordering before creating and processing a block
     std::vector<CMutableTransaction> spends;
-    if(prespends[0].GetHash() > prespends[1].GetHash())
+    if (prespends[0].GetHash() > prespends[1].GetHash())
     {
         spends.push_back(prespends[1]);
         spends.push_back(prespends[0]);

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -2213,7 +2213,14 @@ bool ConnectBlockCanonicalOrdering(const CBlock &block,
         for (unsigned int i = 0; i < block.vtx.size(); i++)
         {
             const CTransaction &tx = *(block.vtx[i]);
-            AddCoins(view, tx, pindex->nHeight);
+            try
+            {
+                AddCoins(view, tx, pindex->nHeight);
+            }
+            catch (std::logic_error &e)
+            {
+                return state.DoS(100, error("CanonicalConnectBlock: repeated-tx"), REJECT_INVALID, "repeated-txn");
+            }
 
             if (i == 1)
             {


### PR DESCRIPTION
catch this exception and return false, rather than letting the exception up the call stack (and run formatting)